### PR TITLE
[feat] Redis 분산락 Timeout이 발생하고 DB Transaction이 유지될 경우 Optimistic Lock을 활용해서 동시성 문제를 제어한다

### DIFF
--- a/backend/src/main/java/com/sjiwon/anotherart/auction/application/usecase/BidUseCase.java
+++ b/backend/src/main/java/com/sjiwon/anotherart/auction/application/usecase/BidUseCase.java
@@ -18,7 +18,8 @@ public class BidUseCase {
     @DistributedLock(
             keyPrefix = "AUCTION:",
             keySuffix = "#command.auctionId",
-            withInTransaction = true
+            withInTransaction = true,
+            withRetry = 3
     )
     public void invoke(final BidCommand command) {
         final Auction auction = auctionRepository.getByIdWithFetchBidder(command.auctionId());

--- a/backend/src/main/java/com/sjiwon/anotherart/auction/domain/model/Auction.java
+++ b/backend/src/main/java/com/sjiwon/anotherart/auction/domain/model/Auction.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,6 +32,9 @@ public class Auction extends BaseEntity<Auction> {
 
     @Embedded
     private HighestBid highestBid;
+
+    @Version
+    private long version;
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "art_id", referencedColumnName = "id", nullable = false, updatable = false)

--- a/backend/src/main/java/com/sjiwon/anotherart/global/lock/DistributedLock.java
+++ b/backend/src/main/java/com/sjiwon/anotherart/global/lock/DistributedLock.java
@@ -20,4 +20,9 @@ public @interface DistributedLock {
     TimeUnit timeUnit() default TimeUnit.MILLISECONDS;
 
     boolean withInTransaction() default false;
+
+    /**
+     * 분산락 Timeout을 고려한 Optimistic Lock Retry
+     */
+    int withRetry() default -1;
 }

--- a/backend/src/main/resources/db/migration/V2__add_optimistic_lock_version.sql
+++ b/backend/src/main/resources/db/migration/V2__add_optimistic_lock_version.sql
@@ -1,0 +1,2 @@
+ALTER TABLE auction
+    ADD COLUMN version BIGINT;


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용

- `Redis 분산락 Timeout`이 발생했는데 DB Transaction이 유지되는 경우 동시성 문제가 발생할 수 있는 여지 존재
  - 이러한 문제에 대해서 `Optimistic Lock`을 통해서 2차적 방어 로직 작성
